### PR TITLE
When 'WhichParMethod' is 0, don't do any concurrency.

### DIFF
--- a/dense_arithmetic.go
+++ b/dense_arithmetic.go
@@ -231,7 +231,7 @@ func (A *DenseMatrix) TimesDenseFill(B, C *DenseMatrix) (err error) {
 		err = ErrorDimensionMismatch
 		return
 	}
-	if runtime.GOMAXPROCS(0) > 1 {
+	if WhichParMethod > 0 && runtime.GOMAXPROCS(0) > 1 {
 		switch WhichParMethod {
 		case 1:
 			parTimes1(A, B, C)


### PR DESCRIPTION
This allows easy disabling of parallel matrix multiplication when GOMAXPROCS > 1. I've added this because the parallel implementations (both of them) don't seem to be beneficial on small matrices, and there was no other way (to my knowledge) to disable parallel computation when GOMAXPROCS > 1.
