### PR TITLE
Fixed some problems with the implementation of sparse matrices

### DIFF
--- a/pivot_arithmetic.go
+++ b/pivot_arithmetic.go
@@ -106,7 +106,7 @@ func (P *PivotMatrix) RowPivotSparse(A *SparseMatrix) (*SparseMatrix, error) {
 	}
 	B := ZerosSparse(A.rows, A.cols)
 	for index, value := range A.elements {
-		si, j := A.GetRowColIndex(index)
+		si, j := A.GetRowColFromIndex(index)
 		di := P.pivots[si]
 		B.Set(di, j, value)
 	}
@@ -123,7 +123,7 @@ func (P *PivotMatrix) ColPivotSparse(A *SparseMatrix) (*SparseMatrix, error) {
 	}
 	B := ZerosSparse(A.rows, A.cols)
 	for index, value := range A.elements {
-		i, sj := A.GetRowColIndex(index)
+		i, sj := A.GetRowColFromIndex(index)
 		dj := P.pivots[sj]
 		B.Set(i, dj, value)
 	}

--- a/pivot_arithmetic.go
+++ b/pivot_arithmetic.go
@@ -106,9 +106,11 @@ func (P *PivotMatrix) RowPivotSparse(A *SparseMatrix) (*SparseMatrix, error) {
 	}
 	B := ZerosSparse(A.rows, A.cols)
 	for index, value := range A.elements {
-		si, j := A.GetRowColFromIndex(index)
-		di := P.pivots[si]
-		B.Set(di, j, value)
+		if A.IsValidIndex(index) {
+			si, j := A.GetRowColFromIndex(index)
+			di := P.pivots[si]
+			B.Set(di, j, value)
+		}
 	}
 
 	return B, nil
@@ -123,10 +125,11 @@ func (P *PivotMatrix) ColPivotSparse(A *SparseMatrix) (*SparseMatrix, error) {
 	}
 	B := ZerosSparse(A.rows, A.cols)
 	for index, value := range A.elements {
-		i, sj := A.GetRowColFromIndex(index)
-		dj := P.pivots[sj]
-		B.Set(i, dj, value)
+		if A.IsValidIndex(index) {
+			i, sj := A.GetRowColFromIndex(index)
+			dj := P.pivots[sj]
+			B.Set(i, dj, value)
+		}
 	}
-
 	return B, nil
 }

--- a/sparse.go
+++ b/sparse.go
@@ -37,11 +37,11 @@ func (A *SparseMatrix) IsValidIndex(index int) bool {
 		return false
 	}
 
-	if index >= A.offset+A.rows*A.step {
+	if (index - A.offset) >= A.rows*A.step {
 		return false
 	}
 
-	if index%A.step >= A.cols {
+	if (index-A.offset)%A.step >= A.cols {
 		return false
 	}
 

--- a/sparse_arithmetic.go
+++ b/sparse_arithmetic.go
@@ -70,7 +70,7 @@ func (A *SparseMatrix) AddSparse(B *SparseMatrix) error {
 	}
 
 	for index, value := range B.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		A.Set(i, j, A.Get(i, j)+value)
 	}
 
@@ -107,7 +107,7 @@ func (A *SparseMatrix) SubtractSparse(B *SparseMatrix) error {
 	}
 
 	for index, value := range B.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		A.Set(i, j, A.Get(i, j)-value)
 	}
 
@@ -131,7 +131,7 @@ func (A *SparseMatrix) Times(B MatrixRO) (Matrix, error) {
 	C := ZerosSparse(A.rows, B.Cols())
 
 	for index, value := range A.elements {
-		i, k := A.GetRowColIndex(index)
+		i, k := A.GetRowColFromIndex(index)
 		//not sure if there is a more efficient way to do this without using
 		//a different data structure
 		for j := 0; j < B.Cols(); j++ {
@@ -156,7 +156,7 @@ func (A *SparseMatrix) TimesSparse(B *SparseMatrix) (*SparseMatrix, error) {
 	C := ZerosSparse(A.rows, B.Cols())
 
 	for index, value := range A.elements {
-		i, k := A.GetRowColIndex(index)
+		i, k := A.GetRowColFromIndex(index)
 		//not sure if there is a more efficient way to do this without using
 		//a different data structure
 		for j := 0; j < B.Cols(); j++ {
@@ -206,7 +206,7 @@ func (A *SparseMatrix) ScaleMatrix(B MatrixRO) error {
 	}
 
 	for index, value := range A.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		A.Set(i, j, value*B.Get(i, j))
 	}
 
@@ -223,7 +223,7 @@ func (A *SparseMatrix) ScaleMatrixSparse(B *SparseMatrix) error {
 		}
 
 		for index, value := range A.elements {
-			i, j := A.GetRowColIndex(index)
+			i, j := A.GetRowColFromIndex(index)
 			A.Set(i, j, value*B.Get(i, j))
 		}
 	}

--- a/sparse_arithmetic.go
+++ b/sparse_arithmetic.go
@@ -70,10 +70,10 @@ func (A *SparseMatrix) AddSparse(B *SparseMatrix) error {
 	}
 
 	for index, value := range B.elements {
-		if (A.IsValidIndex(index)) {
-		i, j := A.GetRowColFromIndex(index)
-		A.Set(i, j, A.Get(i, j)+value)
-	}
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			A.Set(i, j, A.Get(i, j)+value)
+		}
 	}
 
 	return nil
@@ -109,10 +109,10 @@ func (A *SparseMatrix) SubtractSparse(B *SparseMatrix) error {
 	}
 
 	for index, value := range B.elements {
-		if (A.IsValidIndex(index)) {
-		i, j := A.GetRowColFromIndex(index)
-		A.Set(i, j, A.Get(i, j)-value)
-	}
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			A.Set(i, j, A.Get(i, j)-value)
+		}
 	}
 
 	return nil

--- a/sparse_arithmetic.go
+++ b/sparse_arithmetic.go
@@ -131,13 +131,15 @@ func (A *SparseMatrix) Times(B MatrixRO) (Matrix, error) {
 	C := ZerosSparse(A.rows, B.Cols())
 
 	for index, value := range A.elements {
-		i, k := A.GetRowColFromIndex(index)
-		//not sure if there is a more efficient way to do this without using
-		//a different data structure
-		for j := 0; j < B.Cols(); j++ {
-			v := B.Get(k, j)
-			if v != 0 {
-				C.Set(i, j, C.Get(i, j)+value*v)
+		if A.IsValidIndex(index) {
+			i, k := A.GetRowColFromIndex(index)
+			//not sure if there is a more efficient way to do this without using
+			//a different data structure
+			for j := 0; j < B.Cols(); j++ {
+				v := B.Get(k, j)
+				if v != 0 {
+					C.Set(i, j, C.Get(i, j)+value*v)
+				}
 			}
 		}
 	}
@@ -156,13 +158,15 @@ func (A *SparseMatrix) TimesSparse(B *SparseMatrix) (*SparseMatrix, error) {
 	C := ZerosSparse(A.rows, B.Cols())
 
 	for index, value := range A.elements {
-		i, k := A.GetRowColFromIndex(index)
-		//not sure if there is a more efficient way to do this without using
-		//a different data structure
-		for j := 0; j < B.Cols(); j++ {
-			v := B.Get(k, j)
-			if v != 0 {
-				C.Set(i, j, C.Get(i, j)+value*v)
+		if A.IsValidIndex(index) {
+			i, k := A.GetRowColFromIndex(index)
+			//not sure if there is a more efficient way to do this without using
+			//a different data structure
+			for j := 0; j < B.Cols(); j++ {
+				v := B.Get(k, j)
+				if v != 0 {
+					C.Set(i, j, C.Get(i, j)+value*v)
+				}
 			}
 		}
 	}
@@ -175,7 +179,9 @@ Scale this matrix by f.
 */
 func (A *SparseMatrix) Scale(f float64) {
 	for index, value := range A.elements {
-		A.elements[index] = value * f
+		if A.IsValidIndex(index) {
+			A.elements[index] = value * f
+		}
 	}
 }
 
@@ -206,8 +212,10 @@ func (A *SparseMatrix) ScaleMatrix(B MatrixRO) error {
 	}
 
 	for index, value := range A.elements {
-		i, j := A.GetRowColFromIndex(index)
-		A.Set(i, j, value*B.Get(i, j))
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			A.Set(i, j, value*B.Get(i, j))
+		}
 	}
 
 	return nil
@@ -217,15 +225,16 @@ func (A *SparseMatrix) ScaleMatrix(B MatrixRO) error {
 Scale this matrix by another sparse matrix, element-wise. Optimized for sparsity.
 */
 func (A *SparseMatrix) ScaleMatrixSparse(B *SparseMatrix) error {
-	if len(B.elements) > len(A.elements) {
-		if A.rows != B.rows || A.cols != B.cols {
-			return ErrorDimensionMismatch
-		}
+	if A.rows != B.rows || A.cols != B.cols {
+		return ErrorDimensionMismatch
+	}
 
-		for index, value := range A.elements {
+	for index, value := range A.elements {
+		if A.IsValidIndex(index) {
 			i, j := A.GetRowColFromIndex(index)
 			A.Set(i, j, value*B.Get(i, j))
 		}
 	}
-	return A.ScaleMatrix(B)
+
+	return nil
 }

--- a/sparse_arithmetic.go
+++ b/sparse_arithmetic.go
@@ -70,8 +70,10 @@ func (A *SparseMatrix) AddSparse(B *SparseMatrix) error {
 	}
 
 	for index, value := range B.elements {
+		if (A.IsValidIndex(index)) {
 		i, j := A.GetRowColFromIndex(index)
 		A.Set(i, j, A.Get(i, j)+value)
+	}
 	}
 
 	return nil
@@ -107,8 +109,10 @@ func (A *SparseMatrix) SubtractSparse(B *SparseMatrix) error {
 	}
 
 	for index, value := range B.elements {
+		if (A.IsValidIndex(index)) {
 		i, j := A.GetRowColFromIndex(index)
 		A.Set(i, j, A.Get(i, j)-value)
+	}
 	}
 
 	return nil

--- a/sparse_basic.go
+++ b/sparse_basic.go
@@ -12,9 +12,11 @@ Swap two rows in this matrix.
 func (A *SparseMatrix) SwapRows(r1, r2 int) {
 	js := map[int]bool{}
 	for index := range A.elements {
-		i, j := A.GetRowColFromIndex(index)
-		if i == r1 || i == r2 {
-			js[j] = true
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			if i == r1 || i == r2 {
+				js[j] = true
+			}
 		}
 	}
 	for j := range js {
@@ -29,9 +31,11 @@ Scale a row by a scalar.
 */
 func (A *SparseMatrix) ScaleRow(r int, f float64) {
 	for index, value := range A.elements {
-		i, j := A.GetRowColFromIndex(index)
-		if i == r {
-			A.Set(i, j, value*f)
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			if i == r {
+				A.Set(i, j, value*f)
+			}
 		}
 	}
 }
@@ -41,18 +45,22 @@ Add a multiple of row rs to row rd.
 */
 func (A *SparseMatrix) ScaleAddRow(rd, rs int, f float64) {
 	for index, value := range A.elements {
-		i, j := A.GetRowColFromIndex(index)
-		if i == rs {
-			A.Set(rd, j, A.Get(rd, j)+value*f)
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			if i == rs {
+				A.Set(rd, j, A.Get(rd, j)+value*f)
+			}
 		}
 	}
 }
 
 func (A *SparseMatrix) Symmetric() bool {
 	for index, value := range A.elements {
-		i, j := A.GetRowColFromIndex(index)
-		if i != j && value != A.Get(j, i) {
-			return false
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			if i != j && value != A.Get(j, i) {
+				return false
+			}
 		}
 	}
 	return true
@@ -61,8 +69,10 @@ func (A *SparseMatrix) Symmetric() bool {
 func (A *SparseMatrix) Transpose() *SparseMatrix {
 	B := ZerosSparse(A.cols, A.rows)
 	for index, value := range A.elements {
-		i, j := A.GetRowColFromIndex(index)
-		B.Set(j, i, value)
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			B.Set(j, i, value)
+		}
 	}
 	return B
 }
@@ -74,32 +84,40 @@ func (A *SparseMatrix) Det() float64 {
 
 func (A *SparseMatrix) Trace() (res float64) {
 	for index, value := range A.elements {
-		i, j := A.GetRowColFromIndex(index)
-		if i == j {
-			res += value
+		if A.IsValidIndex(index) {
+			i, j := A.GetRowColFromIndex(index)
+			if i == j {
+				res += value
+			}
 		}
 	}
 	return
 }
 
 func (A *SparseMatrix) OneNorm() (res float64) {
-	for _, value := range A.elements {
-		res += math.Abs(value)
+	for index, value := range A.elements {
+		if A.IsValidIndex(index) {
+			res += math.Abs(value)
+		}
 	}
 	return
 }
 
 func (A *SparseMatrix) TwoNorm() float64 {
 	var sum float64 = 0
-	for _, value := range A.elements {
-		sum += value * value
+	for index, value := range A.elements {
+		if A.IsValidIndex(index) {
+			sum += value * value
+		}
 	}
 	return math.Sqrt(sum)
 }
 
 func (A *SparseMatrix) InfinityNorm() (res float64) {
-	for _, value := range A.elements {
-		res = max(res, math.Abs(value))
+	for index, value := range A.elements {
+		if A.IsValidIndex(index) {
+			res = max(res, math.Abs(value))
+		}
 	}
 	return
 }

--- a/sparse_basic.go
+++ b/sparse_basic.go
@@ -12,7 +12,7 @@ Swap two rows in this matrix.
 func (A *SparseMatrix) SwapRows(r1, r2 int) {
 	js := map[int]bool{}
 	for index := range A.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		if i == r1 || i == r2 {
 			js[j] = true
 		}
@@ -29,7 +29,7 @@ Scale a row by a scalar.
 */
 func (A *SparseMatrix) ScaleRow(r int, f float64) {
 	for index, value := range A.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		if i == r {
 			A.Set(i, j, value*f)
 		}
@@ -41,7 +41,7 @@ Add a multiple of row rs to row rd.
 */
 func (A *SparseMatrix) ScaleAddRow(rd, rs int, f float64) {
 	for index, value := range A.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		if i == rs {
 			A.Set(rd, j, A.Get(rd, j)+value*f)
 		}
@@ -50,7 +50,7 @@ func (A *SparseMatrix) ScaleAddRow(rd, rs int, f float64) {
 
 func (A *SparseMatrix) Symmetric() bool {
 	for index, value := range A.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		if i != j && value != A.Get(j, i) {
 			return false
 		}
@@ -61,7 +61,7 @@ func (A *SparseMatrix) Symmetric() bool {
 func (A *SparseMatrix) Transpose() *SparseMatrix {
 	B := ZerosSparse(A.cols, A.rows)
 	for index, value := range A.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		B.Set(j, i, value)
 	}
 	return B
@@ -74,7 +74,7 @@ func (A *SparseMatrix) Det() float64 {
 
 func (A *SparseMatrix) Trace() (res float64) {
 	for index, value := range A.elements {
-		i, j := A.GetRowColIndex(index)
+		i, j := A.GetRowColFromIndex(index)
 		if i == j {
 			res += value
 		}


### PR DESCRIPTION
Hey John,

I had some time to fix up lots of the bugs in the sparse implementation. In particular, when iterating over the elements in the map, you generally would only want to change those elements that are valid members of the current matrix, and not part of some larger matrix.

I think it would be good to make two more significant changes to the package. One would be to change all matrix indexes to an unsigned integer type (probably uint64). One reason is that integer division rounds towards 0 so for the conversions from index to row/col, you can get unexpected results if you don't first check for negatives.

The other major change would be to not export any functions that refer to indexes for sparse matrices. This basically reveals the details of the implementation and if you later want to change the implementation of sparse, or the type of the keys for your map (perhaps to a struct with row and column fields), then you are going to have to break a lot of people's code.

I'm happy to have a go at making these changes if you don't mind.
